### PR TITLE
Two miscellaneous additions

### DIFF
--- a/Core/vm/Interpreter.cs
+++ b/Core/vm/Interpreter.cs
@@ -915,6 +915,12 @@ public class Interpreter : IRunner
 				{
 					if (block.inputs[0].value == "any") return Boolstr(Raylib.GetKeyPressed() > 0);
 
+					if (StrKey(block.inputs[0].value) == KeyboardKey.Null && block.inputs[0].value.Length > 1)
+					{
+						Console.WriteLine(block.inputs[0].value[0]);
+						return Boolstr(Raylib.IsKeyDown(StrKey(block.inputs[0].value[0].ToString())));
+					}
+
 					return Boolstr(Raylib.IsKeyDown(StrKey(block.inputs[0].value)));
 				}
 

--- a/Core/vm/Interpreter.cs
+++ b/Core/vm/Interpreter.cs
@@ -405,6 +405,11 @@ public class Interpreter : IRunner
 					{
 						pos = mousepos;
 					}
+					else if (block.inputs[0].value == "_random_")
+					{
+						spr.direction = rng.Next(-180, 180);
+						break;
+					}
 					else
 					{
 						Sprite destination = Application.project.sprites.First(sprite => sprite.name == block.inputs[0].value);


### PR DESCRIPTION
Implemented two quick miscellaneous additions.

The first one adds a random option to the point towards block (this is implemented in vanilla Scratch, but you need to substitute in a reporter block since it's not in the dropdown menu)

The second one makes it so that a multi-character invalid key names detect the key of the first character (since that's how it works in Scratch)